### PR TITLE
Department link retrieval, saving improvement, fully updated tests

### DIFF
--- a/lowes/__main__.py
+++ b/lowes/__main__.py
@@ -4,6 +4,8 @@ import traceback
 from time import time
 from typing import List, Type
 
+from lowes.scripts.retrieve_department_links import DepartmentLinkRetriever
+from lowes.scripts.retrieve_store_info import StateStoreInfoRetriever
 from lowes.scripts.retrieve_store_links import StateLinkRetriever
 from lowes.utils.classes import TaskRunner
 from lowes.utils.logger import get_logger
@@ -13,6 +15,8 @@ logger = get_logger()
 MAX_CONCURRENCY = 8
 SCRIPTS: List[Type[TaskRunner]] = [
     StateLinkRetriever,
+    StateStoreInfoRetriever,
+    DepartmentLinkRetriever,
 ]
 
 

--- a/lowes/constants.py
+++ b/lowes/constants.py
@@ -14,6 +14,7 @@ CHROMIUM_KWARGS: Dict[str, Any] = {
 
 LOWES_URL = "https://www.lowes.com"
 LOWES_STORES_URL = "https://www.lowes.com/Lowes-Stores"
+LOWES_DEPARTMENTS_URL = "https://www.lowes.com/c/Departments"
 
 DEPARTMENT_LINKS_PATH = path.join(OUTPUT_DIR, "department_links.txt")
 STATE_STORE_LINKS_PATH = path.join(OUTPUT_DIR, "state_links.txt")

--- a/lowes/scripts/retrieve_department_links.py
+++ b/lowes/scripts/retrieve_department_links.py
@@ -30,8 +30,11 @@ class DepartmentLinkRetriever(TaskRunner):
     def save_links(self):
         self.logger.info("Saving department links")
 
+        if len(self.links) == 0:
+            raise Exception("No links to save")
+
         with open(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8") as file:
-            file.write("".join(self.links) + "\n")
+            file.write("".join([link + "\n" for link in self.links]))
 
     async def task(
         self,

--- a/lowes/scripts/retrieve_department_links.py
+++ b/lowes/scripts/retrieve_department_links.py
@@ -1,47 +1,45 @@
-from typing import Any, Coroutine, List
+from typing import Any, List
 
-from playwright.async_api import BrowserContext, Page
+from playwright.async_api import Page
 
-from lowes.constants import DEPARTMENT_LINKS_PATH, LOWES_STORES_URL
-from lowes.utils.logger import get_logger
+from lowes.constants import DEPARTMENT_LINKS_PATH, LOWES_DEPARTMENTS_URL
+from lowes.utils.classes import TaskRunner
 from lowes.utils.playwright import create_page, navigate_to_page
-from lowes.utils.utils import get_full_lowes_url
 
-logger = get_logger()
-
-
-DEPARTMENT_SELECTOR = ".departments-container li.kuxg6u_engage-common-3.foDBid"
-LOWES_DEPARTMENTS_URL = get_full_lowes_url("/departments")
+DEPARTMENT_SELECTOR = ".departments-container li.kuxg6u_engage-common-3.foDBid a"
 
 
-async def get_department_links(page: Page) -> List[str]:
-    logger.info("Getting state links")
+class DepartmentLinkRetriever(TaskRunner):
+    links: List[str]
 
-    dept_link_els = await page.query_selector_all(DEPARTMENT_SELECTOR)
-    links: List[str] = []
+    def __init__(self):
+        super().__init__()
+        self.links = []
 
-    for el in dept_link_els:
-        if href := await el.get_attribute("href"):
-            links.append(href)
-    return links
+    async def get_links(self, page: Page):
+        self.logger.info("Getting department links")
 
+        dept_link_els = await page.query_selector_all(DEPARTMENT_SELECTOR)
+        links: List[str] = []
 
-def save_department_links(links: List[str]) -> None:
-    logger.info("Saving department links")
+        for el in dept_link_els:
+            if href := await el.get_attribute("href"):
+                self.links.append(href)
+        return links
 
-    with open(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8") as file:
-        for link in links:
-            file.write(link + "\n")
+    def save_links(self):
+        self.logger.info("Saving department links")
 
+        with open(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8") as file:
+            file.write("".join(self.links) + "\n")
 
-async def retrieve_department_links(
-    context: BrowserContext,
-) -> List[Coroutine[Any, Any, None]]:
-    page = await create_page(context)
+    async def task(
+        self,
+        page: Page,
+    ) -> None:
+        await navigate_to_page(page, LOWES_DEPARTMENTS_URL)
+        await self.get_links(page)
+        self.save_links()
 
-    async def task() -> None:
-        await navigate_to_page(page, LOWES_STORES_URL)
-        links = await get_department_links(page)
-        save_department_links(links)
-
-    return [task()]
+    async def create_tasks(self, playwright: Any, max_contexts: int):
+        self.tasks.append(self.task(await create_page(playwright)))

--- a/lowes/scripts/retrieve_store_info.py
+++ b/lowes/scripts/retrieve_store_info.py
@@ -47,8 +47,7 @@ def save_store_links(parent_file_path: str, store_links: List[str], state: str) 
     file_path = path.join(parent_file_path, f"{state.lower()}_store_links.txt")
 
     with open(file_path, "w", encoding="utf-8") as file:
-        for store_link in store_links:
-            file.write(store_link + "\n")
+        file.write("".join([store_link + "\n" for store_link in store_links]))
 
 
 async def get_store_links(page: Page) -> List[str]:
@@ -109,8 +108,7 @@ class StateStoreInfoRetriever(TaskRunner):
         file_path = path.join(STATE_STORE_INFO_DIR, f"{state.lower()}_stores.txt")
 
         with open(file_path, "w", encoding="utf-8") as file:
-            for store_info in store_infos:
-                file.write(str(store_info) + "\n")
+            file.write("".join([str(store_info) + "\n" for store_info in store_infos]))
 
         self.logger.info(f"[{state}] - All store info saved successfully")
 

--- a/lowes/scripts/retrieve_store_links.py
+++ b/lowes/scripts/retrieve_store_links.py
@@ -9,46 +9,36 @@ from lowes.utils.playwright import create_page, navigate_to_page
 STATE_LINK_QUERY = "div[data-selector='str-storeDetailContainer'] .backyard.link"
 
 
-async def get_state_links(page: Page) -> List[str]:
-    raw_state_link_els = await page.query_selector_all(STATE_LINK_QUERY)
-    # Skip the first two links, they are not states
-    state_link_els = raw_state_link_els[2:]
-    links: List[str] = []
-
-    for state_link_el in state_link_els:
-        if href := await state_link_el.get_attribute("href"):
-            links.append(href)
-    return links
-
-
-def save_state_links(file_path: str, links: List[str]):
-    with open(file_path, "w", encoding="utf-8") as file:
-        for link in links:
-            file.write(link + "\n")
-
-
 class StateLinkRetriever(TaskRunner):
     links: List[str]
 
     def __init__(self):
         super().__init__()
+        self.links = []
 
     async def get_links(self, page: Page):
         self.logger.info("Getting state links")
-        self.links = await get_state_links(page)
+        raw_state_link_els = await page.query_selector_all(STATE_LINK_QUERY)
+        # Skip the first two links, they are not states
+        state_link_els = raw_state_link_els[2:]
 
-    def save_links(self, links: List[str]):
+        for state_link_el in state_link_els:
+            if href := await state_link_el.get_attribute("href"):
+                self.links.append(href)
+
+    def save_links(self):
         self.logger.info("Saving state links")
 
-        if len(links) == 0:
-            raise Exception("No links to save, exiting")
+        if len(self.links) == 0:
+            raise Exception("No links to save")
 
-        save_state_links(STATE_STORE_LINKS_PATH, self.links)
+        with open(STATE_STORE_LINKS_PATH, "w", encoding="utf-8") as file:
+            file.write("".join([link + "\n" for link in self.links]))
 
     async def task(self, page: Page) -> None:
         await navigate_to_page(page, LOWES_STORES_URL)
         await self.get_links(page)
-        self.save_links(self.links)
+        self.save_links()
 
     async def create_tasks(self, playwright: Playwright, max_contexts: int):
         self.tasks.append(self.task(await create_page(playwright)))

--- a/lowes/utils/proxy.py
+++ b/lowes/utils/proxy.py
@@ -68,7 +68,7 @@ class ProxyManager(Singleton):
         self.instantiated = True
 
     def read_proxy_list(self) -> list[str]:
-        logger.info("Reading proxy list")
+        logger.info("[Proxy] Reading proxy list")
 
         with open(PROXIES_FILE_PATH, "r", encoding="utf-8") as file:
             proxies = file.readlines()

--- a/tests/test_retrieve_department_links.py
+++ b/tests/test_retrieve_department_links.py
@@ -1,0 +1,46 @@
+from unittest.mock import Mock, mock_open, patch
+
+from playwright.async_api import BrowserContext, Page
+
+from lowes.constants import DEPARTMENT_LINKS_PATH, LOWES_DEPARTMENTS_URL
+from lowes.scripts.retrieve_department_links import DepartmentLinkRetriever
+from lowes.utils.playwright import navigate_to_page
+
+TEST_DEPT_LINKS = [
+    "/pl/Accessible-bathroom-Accessible-home/37721669146437",
+    "/pl/Accessible-bedroom-Accessible-home/4294644781",
+    "/pl/Accessible-entry-home-Accessible-home/37721669146444",
+    "/pl/Accessible-kitchen-Accessible-home/1111913019980",
+]
+
+NUM_DEPT_LINKS = 384  # This number is from the initial full run
+
+
+async def test_lowes_get_department_links(page: Page):
+    client = DepartmentLinkRetriever()
+    await navigate_to_page(page, LOWES_DEPARTMENTS_URL)
+    await client.get_links(page)
+    assert len(client.links) == NUM_DEPT_LINKS
+
+
+@patch("builtins.open", new_callable=mock_open)
+def test_save_department_links(mock_open_arg: Mock):
+    client = DepartmentLinkRetriever()
+    client.links = TEST_DEPT_LINKS
+    client.save_links()
+
+    mock_open_arg.assert_called_once_with(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8")
+    handle = mock_open_arg()
+
+    assert handle.write.call_args_list[0].args[0] == "".join(TEST_DEPT_LINKS) + "\n"
+    assert handle.write.call_count == 1
+
+
+@patch("builtins.open", new_callable=mock_open)
+async def test_main(mock_open_arg: Mock, context: BrowserContext):
+    client = DepartmentLinkRetriever()
+    await client.main(1)
+    mock_open_arg.assert_called_once_with(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8")
+    handle = mock_open_arg()
+    assert handle.write.call_count == 1
+    assert len(client.links) == NUM_DEPT_LINKS

--- a/tests/test_retrieve_department_links.py
+++ b/tests/test_retrieve_department_links.py
@@ -1,17 +1,11 @@
 from unittest.mock import Mock, mock_open, patch
 
+import pytest
 from playwright.async_api import BrowserContext, Page
 
 from lowes.constants import DEPARTMENT_LINKS_PATH, LOWES_DEPARTMENTS_URL
 from lowes.scripts.retrieve_department_links import DepartmentLinkRetriever
 from lowes.utils.playwright import navigate_to_page
-
-TEST_DEPT_LINKS = [
-    "/pl/Accessible-bathroom-Accessible-home/37721669146437",
-    "/pl/Accessible-bedroom-Accessible-home/4294644781",
-    "/pl/Accessible-entry-home-Accessible-home/37721669146444",
-    "/pl/Accessible-kitchen-Accessible-home/1111913019980",
-]
 
 NUM_DEPT_LINKS = 384  # This number is from the initial full run
 
@@ -23,16 +17,32 @@ async def test_lowes_get_department_links(page: Page):
     assert len(client.links) == NUM_DEPT_LINKS
 
 
+def test_no_len_save_links():
+    client = DepartmentLinkRetriever()
+    client.links = []
+    with pytest.raises(Exception) as e:
+        client.save_links()
+        assert "No links to save" in str(e)
+
+
 @patch("builtins.open", new_callable=mock_open)
 def test_save_department_links(mock_open_arg: Mock):
+    test_links = [
+        "/pl/Accessible-bathroom-Accessible-home/37721669146437",
+        "/pl/Accessible-bedroom-Accessible-home/4294644781",
+        "/pl/Accessible-entry-home-Accessible-home/37721669146444",
+        "/pl/Accessible-kitchen-Accessible-home/1111913019980",
+    ]
+
     client = DepartmentLinkRetriever()
-    client.links = TEST_DEPT_LINKS
+    client.links = test_links
     client.save_links()
 
     mock_open_arg.assert_called_once_with(DEPARTMENT_LINKS_PATH, "w", encoding="utf-8")
     handle = mock_open_arg()
 
-    assert handle.write.call_args_list[0].args[0] == "".join(TEST_DEPT_LINKS) + "\n"
+    test_link_str = "".join([link + "\n" for link in test_links])
+    assert test_link_str == handle.write.call_args_list[0].args[0]
     assert handle.write.call_count == 1
 
 

--- a/tests/test_retrieve_store_info.py
+++ b/tests/test_retrieve_store_info.py
@@ -50,9 +50,9 @@ async def test_save_store_links(mock_open_arg: Mock):
     mock_open_arg.assert_called_once_with(mock_file_path, "w", encoding="utf-8")
     handle = mock_open_arg()
 
-    for link in mock_store_links:
-        handle.write.assert_any_call(link + "\n")
-    assert handle.write.call_count == len(mock_store_links)
+    mock_store_string = "".join([link + "\n" for link in mock_store_links])
+    assert handle.write.call_args_list[0].args[0] == mock_store_string
+    assert handle.write.call_count == 1
 
 
 async def test_parse_store_page(page: Page):

--- a/tests/test_retrieve_store_info.py
+++ b/tests/test_retrieve_store_info.py
@@ -124,8 +124,6 @@ async def test_get_store_infos_for_state(
     )
     assert mock_get_state_store_links.call_args_list[0].kwargs["state"] == STATE
 
-    print(mock_process_all_state_stores.call_args_list)
-    print(mock_process_all_state_stores.call_args_list[0].kwargs)
     mock_process_all_state_stores.assert_called_once()
     assert (
         mock_process_all_state_stores.call_args_list[0].kwargs["store_links"]


### PR DESCRIPTION
# Description

- Added the `DepartmentLinkRetriever` to retrieve all of the department URLs
- Improved the saving processes for all scripts by taking the list of items, using list comprehension to append all the items into a string followed by a newline character.
  - This is an improvement from making a `write()` call for each entry and instead, is only done once
- Full updated tests
